### PR TITLE
Unbreak on BSDs

### DIFF
--- a/test.h
+++ b/test.h
@@ -8,6 +8,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#include <unistd.h> // getpid
+#endif
+
 struct test_file_metadata;
 
 struct test_failure {
@@ -91,11 +96,31 @@ extern void __attribute__((weak)) (*test_h_unittest_setup)(void);
 /// @param[out] tests_run if not NULL, set to whether tests were run
 static inline void __attribute__((constructor(102))) run_tests(void) {
 	bool should_run = false;
+#ifdef KERN_PROC_ARGS
+	int mib[] = {
+		CTL_KERN,
+#if defined(__NetBSD__) || defined(__OpenBSD__)
+		KERN_PROC_ARGS,
+		getpid(),
+		KERN_PROC_ARGV,
+#else
+		KERN_PROC,
+		KERN_PROC_ARGS,
+		getpid(),
+#endif
+	};
+	char *arg = NULL;
+	size_t arglen;
+	sysctl(mib, sizeof(mib)/sizeof(mib[0]), NULL, &arglen, NULL, 0);
+	arg = malloc(arglen);
+	sysctl(mib, sizeof(mib)/sizeof(mib[0]), arg, &arglen, NULL, 0);
+#else
 	FILE *cmdlinef = fopen("/proc/self/cmdline", "r");
 	char *arg = NULL;
 	int arglen;
 	fscanf(cmdlinef, "%ms%n", &arg, &arglen);
 	fclose(cmdlinef);
+#endif
 	for (char *pos = arg; pos < arg + arglen; pos += strlen(pos) + 1) {
 		if (strcmp(pos, "--unittest") == 0) {
 			should_run = true;


### PR DESCRIPTION
`/proc` is deprecated and not mounted by default on FreeBSD and NetBSD while DragonFly and OpenBSD completely removed the code.

```
$ cc --version
FreeBSD clang version 9.0.0 (tags/RELEASE_900/final 372316) (based on LLVM 9.0.0)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin

$ cat foo.c
#include "test.h"

TEST_CASE(test_case_name) {
	TEST_EQUAL(1, 1);
}

int main() {
  return 0;
}

$ cc -g -DUNIT_TEST -I. -o foo foo.c
$ ./foo

Program received signal SIGSEGV, Segmentation fault.
__svfscanf (fp=0x0, locale=0x800434598 <__xlocale_global_locale>, fmt0=0x200781 "%ms%n", ap=0x7fffffffd220)
    at /usr/src/lib/libc/stdio/vfscanf.c:484
484             ORIENT(fp, -1);
(gdb) bt
#0  __svfscanf (fp=0x0, locale=0x800434598 <__xlocale_global_locale>, fmt0=0x200781 "%ms%n", ap=0x7fffffffd220)
    at /usr/src/lib/libc/stdio/vfscanf.c:484
#1  0x00000008003e19d6 in fscanf (fp=0x0, fmt=0x200781 "%ms%n") at /usr/src/lib/libc/stdio/fscanf.c:62
#2  0x000000000020132e in run_tests () at ./test.h:97
#3  0x000000080020b94d in objlist_call_init (list=<optimized out>, lockstate=<optimized out>)
    at /usr/src/libexec/rtld-elf/rtld.c:2740
#4  0x000000080020a3f9 in _rtld (sp=<optimized out>, exit_proc=0x7fffffffe230, objp=0x7fffffffe238)
    at /usr/src/libexec/rtld-elf/rtld.c:771
#5  0x0000000800208019 in .rtld_start () at /usr/src/libexec/rtld-elf/amd64/rtld_start.S:39
#6  0x0000000000000000 in ?? ()
```
