### PR TITLE
Unbreak build with GCC on FreeBSD

### DIFF
--- a/test.h
+++ b/test.h
@@ -11,6 +11,7 @@
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) ||     \
     defined(__NetBSD__) || defined(__OpenBSD__)
 #define USE_SYSCTL_FOR_ARGS 1
+#include <sys/types.h>
 #include <sys/sysctl.h>
 #include <unistd.h>        // getpid
 #endif


### PR DESCRIPTION
Found [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=241724). Clang (unlike GCC) doesn't complain, probably because `<sys/types.h>` is included via another header.
```c
$ pkg install gcc
$ make -C examples/trivial_tests
gcc -O test_test1.c test_test2.c -I../../ -o normal
gcc -g test_test1.c test_test2.c -DUNIT_TEST -I../../ -o unittest
In file included from ../../test.h:14,
                 from test_test1.c:3:
/usr/include/sys/sysctl.h:1153:25: error: unknown type name 'u_int'; did you mean 'int'?
 1153 | int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
      |                         ^~~~~
      |                         int
In file included from test_test1.c:3:
../../test.h: In function 'run_tests':
../../test.h:114:2: warning: implicit declaration of function 'sysctl'; did you mean 'syscall'? [-Wimplicit-function-declaration]
  114 |  sysctl(mib, sizeof(mib) / sizeof(mib[0]), NULL, &arglen, NULL, 0);
      |  ^~~~~~
      |  syscall
In file included from ../../test.h:14,
                 from test_test2.c:2:
/usr/include/sys/sysctl.h:1153:25: error: unknown type name 'u_int'; did you mean 'int'?
 1153 | int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
      |                         ^~~~~
      |                         int
In file included from test_test2.c:2:
../../test.h: In function 'run_tests':
../../test.h:114:2: warning: implicit declaration of function 'sysctl'; did you mean 'syscall'? [-Wimplicit-function-declaration]
  114 |  sysctl(mib, sizeof(mib) / sizeof(mib[0]), NULL, &arglen, NULL, 0);
      |  ^~~~~~
      |  syscall
*** Error code 1

Stop.
make: stopped in /path/to/test.h/examples/trivial_tests
```
Simplified:
```c
$ clang -xc -c -include sys/sysctl.h /dev/null
In file included from <built-in>:1:
/usr/include/sys/sysctl.h:1153:40: error: unknown type name 'size_t'
int     sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
                                           ^
/usr/include/sys/sysctl.h:1154:40: error: unknown type name 'size_t'
int     sysctlbyname(const char *, void *, size_t *, const void *, size_t);
                                           ^
/usr/include/sys/sysctl.h:1155:42: error: unknown type name 'size_t'
int     sysctlnametomib(const char *, int *, size_t *);
                                             ^
3 errors generated.

$ gcc -xc -c -include sys/sysctl.h /dev/null
In file included from <command-line>:31:
/usr/include/sys/sysctl.h:1153:25: error: unknown type name 'u_int'; did you mean 'int'?
 1153 | int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
      |                         ^~~~~
      |                         int
/usr/include/sys/sysctl.h:1153:40: error: unknown type name 'size_t'
 1153 | int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
      |                                        ^~~~~~
/usr/include/sys/sysctl.h:1151:1: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
 1150 | #include <sys/cdefs.h>
  +++ |+#include <stddef.h>
 1151 |
/usr/include/sys/sysctl.h:1153:64: error: unknown type name 'size_t'
 1153 | int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
      |                                                                ^~~~~~
/usr/include/sys/sysctl.h:1153:64: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
/usr/include/sys/sysctl.h:1154:40: error: unknown type name 'size_t'
 1154 | int sysctlbyname(const char *, void *, size_t *, const void *, size_t);
      |                                        ^~~~~~
/usr/include/sys/sysctl.h:1154:40: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
/usr/include/sys/sysctl.h:1154:64: error: unknown type name 'size_t'
 1154 | int sysctlbyname(const char *, void *, size_t *, const void *, size_t);
      |                                                                ^~~~~~
/usr/include/sys/sysctl.h:1154:64: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
/usr/include/sys/sysctl.h:1155:42: error: unknown type name 'size_t'
 1155 | int sysctlnametomib(const char *, int *, size_t *);
      |                                          ^~~~~~
/usr/include/sys/sysctl.h:1155:42: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
```
